### PR TITLE
Fix NanoVDB array ownership.

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -114,6 +114,8 @@ int main(int argc, char* argv[])
 
         editor.add_nanovdb_2(&editor, scene_main, volume_token, data_nanovdb);
 
+        compute.destroy_array(data_nanovdb);
+
         editor.show(&editor, device, &config);
 
         pnanovdb_editor_free(&editor);
@@ -161,6 +163,9 @@ int main(int argc, char* argv[])
             pnanovdb_editor_token_t* volume_token = inst.editor.get_token("dragon");
             inst.editor.add_nanovdb_2(&inst.editor, scene_token, volume_token, inst.nanovdb_array);
 
+            inst.compute.destroy_array(inst.nanovdb_array);
+            inst.nanovdb_array = nullptr;
+
             pnanovdb_editor_config_t config = {};
             config.ip_address = args.ip_address.c_str();
             config.port = args.port + inst_idx;
@@ -197,6 +202,9 @@ int main(int argc, char* argv[])
                 pnanovdb_editor_token_t* scene_token = inst.editor.get_token("main");
                 pnanovdb_editor_token_t* volume_token = inst.editor.get_token("dragon");
                 inst.editor.add_nanovdb_2(&inst.editor, scene_token, volume_token, inst.nanovdb_array);
+
+                inst.compute.destroy_array(inst.nanovdb_array);
+                inst.nanovdb_array = nullptr;
             }
         }
 #endif

--- a/compute/Compute.cpp
+++ b/compute/Compute.cpp
@@ -554,6 +554,11 @@ pnanovdb_compute_array_t* create_array(size_t element_size, pnanovdb_uint64_t el
     return array;
 }
 
+pnanovdb_compute_array_t* duplicate_array(pnanovdb_compute_array_t* array)
+{
+    return create_array(array->element_size, array->element_count, array->data);
+}
+
 void destroy_array(pnanovdb_compute_array_t* array)
 {
     if (!array)
@@ -689,6 +694,7 @@ PNANOVDB_API pnanovdb_compute_t* pnanovdb_get_compute()
     compute.dispatch_shader_on_nanovdb_array = dispatch_shader_on_nanovdb_array;
     compute.create_array = create_array;
     compute.destroy_array = destroy_array;
+    compute.duplicate_array = duplicate_array;
     compute.map_array = map_array;
     compute.unmap_array = unmap_array;
     compute.compute_array_print_range = compute_array_print_range;

--- a/editor/Editor.cpp
+++ b/editor/Editor.cpp
@@ -1098,12 +1098,15 @@ static inline const char* token_to_string(pnanovdb_editor_token_t* token)
 void add_nanovdb_2(pnanovdb_editor_t* editor,
                    pnanovdb_editor_token_t* scene,
                    pnanovdb_editor_token_t* name,
-                   pnanovdb_compute_array_t* array)
+                   pnanovdb_compute_array_t* array_in)
 {
-    if (!editor || !editor->impl || !scene || !name || !array)
+    if (!editor || !editor->impl || !scene || !name || !array_in)
     {
         return;
     }
+
+    // we need to duplicate array for now to take proper ownership
+    pnanovdb_compute_array_t* array = editor->impl->compute->duplicate_array(array_in);
 
     Console::getInstance().addLog(Console::LogLevel::Debug, "add_nanovdb_2: scene='%s' (id=%llu), name='%s' (id=%llu)",
                                   token_to_string(scene), (unsigned long long)scene->id, token_to_string(name),

--- a/nanovdb_editor/putil/Compute.h
+++ b/nanovdb_editor/putil/Compute.h
@@ -835,6 +835,7 @@ typedef struct pnanovdb_compute_t
                                                           pnanovdb_uint64_t element_count,
                                                           const void* data);
     void(PNANOVDB_ABI* destroy_array)(pnanovdb_compute_array_t* array);
+    pnanovdb_compute_array_t*(PNANOVDB_ABI* duplicate_array)(pnanovdb_compute_array_t* array);
     void*(PNANOVDB_ABI* map_array)(pnanovdb_compute_array_t* array);
     void(PNANOVDB_ABI* unmap_array)(pnanovdb_compute_array_t* array);
     void(PNANOVDB_ABI* compute_array_print_range)(const pnanovdb_compute_t* compute,
@@ -861,6 +862,7 @@ PNANOVDB_REFLECT_FUNCTION_POINTER(dispatch_shader_on_array, 0, 0)
 PNANOVDB_REFLECT_FUNCTION_POINTER(dispatch_shader_on_nanovdb_array, 0, 0)
 PNANOVDB_REFLECT_FUNCTION_POINTER(create_array, 0, 0)
 PNANOVDB_REFLECT_FUNCTION_POINTER(destroy_array, 0, 0)
+PNANOVDB_REFLECT_FUNCTION_POINTER(duplicate_array, 0, 0)
 PNANOVDB_REFLECT_FUNCTION_POINTER(map_array, 0, 0)
 PNANOVDB_REFLECT_FUNCTION_POINTER(unmap_array, 0, 0)
 PNANOVDB_REFLECT_FUNCTION_POINTER(compute_array_print_range, 0, 0)

--- a/pymodule/nanovdb_editor/compute.py
+++ b/pymodule/nanovdb_editor/compute.py
@@ -134,6 +134,7 @@ class pnanovdb_Compute(Structure):
         ),  # readback_buffer
         ("create_array", CFUNCTYPE(POINTER(pnanovdb_ComputeArray), c_size_t, c_uint64, c_void_p)),
         ("destroy_array", CFUNCTYPE(None, POINTER(pnanovdb_ComputeArray))),
+        ("duplicate_array", CFUNCTYPE(POINTER(pnanovdb_ComputeArray), POINTER(pnanovdb_ComputeArray))),
         ("map_array", CFUNCTYPE(c_void_p, POINTER(pnanovdb_ComputeArray))),
         ("unmap_array", CFUNCTYPE(None, POINTER(pnanovdb_ComputeArray))),
         (
@@ -210,6 +211,13 @@ class Compute:
         if not array:
             raise RuntimeError("Failed to create compute array")
         return array.contents
+
+    def duplicate_array(self, array: pnanovdb_ComputeArray) -> pnanovdb_ComputeArray:
+        dup_func = self._compute.contents.duplicate_array
+        dup_array = dup_func(pointer(array))
+        if not dup_array:
+            raise RuntimeError("Failed to duplicate compute array")
+        return dup_array.contents
 
     def destroy_array(self, array: pnanovdb_ComputeArray) -> None:
         destroy_func = self._compute.contents.destroy_array

--- a/pymodule/test_cpp/main.cpp
+++ b/pymodule/test_cpp/main.cpp
@@ -229,6 +229,9 @@ int main(int argc, char* argv[])
         editor.add_nanovdb_2(&editor, scene_secondary, flow_token, data_nanovdb2);
     }
 
+    compute.destroy_array(data_nanovdb);
+    compute.destroy_array(data_nanovdb2);
+
     printf("Scene Summary:\n");
     printf("  main_scene: dragon\n");
     printf("  secondary_scene: dragon + flow_volume\n");

--- a/raster/test_raster.py
+++ b/raster/test_raster.py
@@ -149,6 +149,8 @@ if __name__ == "__main__":
         compute.destroy_array(sh_array)
         compute.destroy_array(opacities_array)
 
+        compute.destroy_array(nvdb_array)
+
     if TEST_RASTER_TO_NANOVDB:
         raster_func(TEST_NPZ)
         compute.save_nanovdb(editor.get_nanovdb(), TEST_NANOVDB)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -413,6 +413,9 @@ int main(int argc, char* argv[])
     editor.add_nanovdb_2(&editor, scene_token, volume_token, data_nanovdb);
     editor.add_nanovdb_2(&editor, main_token, volume_token, data_nanovdb);
 
+    compute.destroy_array(data_nanovdb);
+    compute.destroy_array(data_nanovdb2);
+
     runEditorLoop(100);
 
     editor.stop(&editor);

--- a/test/test_editor.py
+++ b/test/test_editor.py
@@ -26,6 +26,8 @@ if __name__ == "__main__":
     dragon_token = editor.get_token("dragon")
     editor.add_nanovdb_2(scene_token, dragon_token, nvdb_array)
 
+    compute.destroy_array(nvdb_array)
+
     config = EditorConfig()
     config.ip_address = b"127.0.0.1"
     config.port = 8080


### PR DESCRIPTION
To make add_nanovdb_2() behave the same way as add_gaussian_data_2(), array parameters should be treated as read-only and owned by the client. Server must duplicate to get its own ownership. Later this can evolve to add_ref() instead.

Tried to search through code and find all missing array destroy due to previous behavior of transferring ownership. 