### PR TITLE
SDF surface rendering via HDDA zero-crossing.

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1121,7 +1121,7 @@ jobs:
   fvdb-viz-integration:
     name: fVDB Integration (release)
     needs: [build_linux_x86_wheel]
-    if: ${{ !cancelled() && needs.build_linux_x86_wheel.result == 'success' && inputs.run_fvdb_viz_integration }}
+    if: ${{ !cancelled() && needs.build_linux_x86_wheel.result == 'success' && inputs.run_fvdb_viz_integration && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     uses: ./.github/workflows/fvdb-viz-integration.yml
     with:
       package: ${{ inputs.is_dev && 'dev' || 'release' }}
@@ -1133,7 +1133,7 @@ jobs:
   fvdb-viz-integration-nightly:
     name: fVDB Integration (nightly)
     needs: [build_linux_x86_wheel]
-    if: ${{ !cancelled() && needs.build_linux_x86_wheel.result == 'success' && inputs.run_fvdb_viz_integration }}
+    if: ${{ !cancelled() && needs.build_linux_x86_wheel.result == 'success' && inputs.run_fvdb_viz_integration && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     uses: ./.github/workflows/fvdb-viz-integration.yml
     with:
       package: ${{ inputs.is_dev && 'dev' || 'release' }}

--- a/editor/Pipeline.cpp
+++ b/editor/Pipeline.cpp
@@ -1238,6 +1238,9 @@ static void* map_voxelbvh_build_params(pnanovdb_scene_object_t* obj)
 PNANOVDB_DEFINE_PIPELINE_SHADERS(s_nanovdb_render_shaders,
                                  PNANOVDB_PIPELINE_SHADER("editor/editor.slang", nullptr, PNANOVDB_TRUE));
 
+PNANOVDB_DEFINE_PIPELINE_SHADERS(s_nanovdb_surface_shaders,
+                                 PNANOVDB_PIPELINE_SHADER("editor/editor_surface.slang", nullptr, PNANOVDB_TRUE));
+
 PNANOVDB_DEFINE_PIPELINE_SHADERS(s_raster2d_shaders,
                                  PNANOVDB_PIPELINE_SHADER("raster/gaussian_rasterize_2d.slang",
                                                           "raster/raster2d_group",
@@ -1298,6 +1301,22 @@ static const pnanovdb_pipeline_descriptor_t s_nanovdb_render_descriptor = {
     pnanovdb_pipeline_stage_render,
     "NanoVDB Render",
     s_nanovdb_render_shaders,
+    1,
+    sizeof(NanoVDBRenderParams),
+    "NanoVDBRenderParams",
+    init_nanovdb_render_params,
+    execute_nanovdb_render,
+    get_render_method_nanovdb,
+    map_nanovdb_render_params,
+    nullptr,
+    0 // param_fields
+};
+
+static const pnanovdb_pipeline_descriptor_t s_nanovdb_surface_descriptor = {
+    pnanovdb_pipeline_type_nanovdb_surface,
+    pnanovdb_pipeline_stage_render,
+    "NanoVDB Surface (SDF)",
+    s_nanovdb_surface_shaders,
     1,
     sizeof(NanoVDBRenderParams),
     "NanoVDBRenderParams",
@@ -1869,6 +1888,7 @@ void pipeline_register_builtins()
 {
     pnanovdb_pipeline_register(&s_noop_descriptor);
     pnanovdb_pipeline_register(&s_nanovdb_render_descriptor);
+    pnanovdb_pipeline_register(&s_nanovdb_surface_descriptor);
     pnanovdb_pipeline_register(&s_raster2d_descriptor);
     pnanovdb_pipeline_register(&s_raster3d_descriptor);
     pnanovdb_pipeline_register(&s_voxelbvh_render_descriptor);

--- a/editor/PipelineTypes.h
+++ b/editor/PipelineTypes.h
@@ -23,5 +23,6 @@ enum pnanovdb_pipeline_type_enum_t
     pnanovdb_pipeline_type_voxelbvh_triangles_debug_render = 7,
     pnanovdb_pipeline_type_voxelbvh_debug_render = 8,
     pnanovdb_pipeline_type_voxelbvh_build = 9,
+    pnanovdb_pipeline_type_nanovdb_surface = 10,
     pnanovdb_pipeline_type_count
 };

--- a/editor/shaders/editor_surface.slang
+++ b/editor/shaders/editor_surface.slang
@@ -3,15 +3,14 @@
 // SDF / level-set isosurface renderer.
 //
 // Finds the first zero-crossing of the signed scalar field along each camera
-// ray using hierarchical DDA traversal (the PNanoVDB HDDA helpers enabled via
-// PNANOVDB_HDDA), then shades the hit as an opaque surface. Supports FLOAT and
-// ONINDEX (float blind-data) grids. Output uses the same premultiplied
-// alpha-as-transmittance convention as editor.slang: alpha 0 == opaque,
-// alpha 1 == fully transparent (background shows through).
+// ray using the PNanoVDB hierarchical DDA helpers (PNANOVDB_HDDA, enabled by
+// default for HLSL in PNanoVDB.h), then shades the hit as an opaque surface.
+// Supports FLOAT and ONINDEX (float blind-data) grids. Output uses the same
+// premultiplied alpha-as-transmittance convention as editor.slang: alpha 0 ==
+// opaque, alpha 1 == fully transparent (background shows through).
 #define PNANOVDB_HLSL
 #define PNANOVDB_ADDRESS_64
 #define PNANOVDB_BUF_HLSL_64
-#define PNANOVDB_HDDA
 #include "PNanoVDB.h"
 
 #include "editor_params.slang"
@@ -20,7 +19,7 @@ struct shader_params_t
 {
     float isovalue;     // iso level to extract (0 for level sets)
     float surface_eps;  // index-space bisection tolerance (<= 0 disables refinement)
-    uint auto_center;    // reserved for parity with editor.slang (unused: HDDA traverses true index space)
+    uint auto_center;    // recenter the traversal near the origin in index space (float precision for off-origin grids)
     float ambient;      // ambient lighting term
 
     float4 light_dir;     // world-space light direction; (0,0,0) -> headlight
@@ -90,14 +89,17 @@ float read_distance(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf,
     return value;
 }
 
-// Trilinearly interpolated distance at an arbitrary index-space position. Voxel
-// values are treated as samples at integer (cell-center) coordinates, matching
-// editor.slang's compute_trilinear_weights convention.
-float read_distance_trilinear(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, float3 pos)
+// Trilinearly interpolated distance at an arbitrary position expressed in
+// recentered ("local") index space. Voxel values are treated as samples at
+// integer (cell-center) coordinates, matching editor.slang's
+// compute_trilinear_weights convention. ijk_offset (a multiple of 4096, see
+// auto_center) is added back to recover the true coordinate for each lookup.
+float read_distance_trilinear(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, float3 pos, int3 ijk_offset)
 {
     float3 p = pos - 0.5f;
-    int3 ijk000 = int3(floor(p));
-    float3 w = p - float3(ijk000);
+    int3 base = int3(floor(p));
+    float3 w = p - float3(base);
+    int3 ijk000 = base + ijk_offset;
 
     float result = 0.f;
     [unroll]
@@ -113,16 +115,17 @@ float read_distance_trilinear(pnanovdb_grid_type_t grid_type, StructuredBuffer<u
 }
 
 // Index-space surface normal = normalized gradient of the field via central
-// differences of the trilinearly sampled distance.
-float3 surface_normal(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, float3 pos)
+// differences of the trilinearly sampled distance. pos is in recentered index
+// space; the offset is direction-invariant so the normal is unaffected by it.
+float3 surface_normal(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, float3 pos, int3 ijk_offset)
 {
     const float h = 1.f;
-    float dx = read_distance_trilinear(grid_type, buf, acc, pos + float3(h, 0.f, 0.f)) -
-               read_distance_trilinear(grid_type, buf, acc, pos - float3(h, 0.f, 0.f));
-    float dy = read_distance_trilinear(grid_type, buf, acc, pos + float3(0.f, h, 0.f)) -
-               read_distance_trilinear(grid_type, buf, acc, pos - float3(0.f, h, 0.f));
-    float dz = read_distance_trilinear(grid_type, buf, acc, pos + float3(0.f, 0.f, h)) -
-               read_distance_trilinear(grid_type, buf, acc, pos - float3(0.f, 0.f, h));
+    float dx = read_distance_trilinear(grid_type, buf, acc, pos + float3(h, 0.f, 0.f), ijk_offset) -
+               read_distance_trilinear(grid_type, buf, acc, pos - float3(h, 0.f, 0.f), ijk_offset);
+    float dy = read_distance_trilinear(grid_type, buf, acc, pos + float3(0.f, h, 0.f), ijk_offset) -
+               read_distance_trilinear(grid_type, buf, acc, pos - float3(0.f, h, 0.f), ijk_offset);
+    float dz = read_distance_trilinear(grid_type, buf, acc, pos + float3(0.f, 0.f, h), ijk_offset) -
+               read_distance_trilinear(grid_type, buf, acc, pos - float3(0.f, 0.f, h), ijk_offset);
     float3 n = float3(dx, dy, dz);
     float len = length(n);
     return (len > 1e-8f) ? (n / len) : float3(0.f, 0.f, 1.f);
@@ -142,14 +145,17 @@ bool surface_zero_crossing(pnanovdb_grid_type_t grid_type,
                            float tmax,
                            float isovalue,
                            float eps,
+                           int3 ijk_offset,
                            out float thit)
 {
     thit = tmin;
 
+    // origin/direction are in recentered ("local") index space; shift the true
+    // root bbox by the same offset so the HDDA float math stays near the origin.
     pnanovdb_coord_t bbox_min = pnanovdb_root_get_bbox_min(buf, acc.root);
     pnanovdb_coord_t bbox_max = pnanovdb_root_get_bbox_max(buf, acc.root);
-    float3 bbox_minf = pnanovdb_coord_to_vec3(bbox_min);
-    float3 bbox_maxf = pnanovdb_coord_to_vec3(pnanovdb_coord_add(bbox_max, pnanovdb_coord_uniform(1)));
+    float3 bbox_minf = float3(bbox_min - ijk_offset);
+    float3 bbox_maxf = float3(bbox_max - ijk_offset + int3(1, 1, 1));
 
     bool hit = pnanovdb_hdda_ray_clip(bbox_minf, bbox_maxf, origin, tmin, direction, tmax);
     if (!hit || tmax > 1.0e20f)
@@ -160,27 +166,28 @@ bool surface_zero_crossing(pnanovdb_grid_type_t grid_type,
     float3 pos = pnanovdb_hdda_ray_start(origin, tmin, direction);
     pnanovdb_coord_t ijk = pnanovdb_hdda_pos_to_ijk(pos);
 
-    float v0 = read_distance(grid_type, buf, acc, ijk);
+    // ijk is in local space; add ijk_offset back to recover the true coordinate
+    // for every accessor / value lookup.
+    float v0 = read_distance(grid_type, buf, acc, ijk + ijk_offset);
     float d_prev = v0 - isovalue;
     float t_prev = tmin;
 
-    int dim = pnanovdb_uint32_as_int32(pnanovdb_readaccessor_get_dim(grid_type, buf, acc, ijk));
+    int dim = pnanovdb_uint32_as_int32(pnanovdb_readaccessor_get_dim(grid_type, buf, acc, ijk + ijk_offset));
     pnanovdb_hdda_t hdda;
     pnanovdb_hdda_init(hdda, origin, tmin, direction, tmax, dim);
     while (pnanovdb_hdda_step(hdda))
     {
         float3 pos_start = pnanovdb_hdda_ray_start(origin, hdda.tmin + 1.0001f, direction);
         ijk = pnanovdb_hdda_pos_to_ijk(pos_start);
-        dim = pnanovdb_uint32_as_int32(pnanovdb_readaccessor_get_dim(grid_type, buf, acc, ijk));
+        dim = pnanovdb_uint32_as_int32(pnanovdb_readaccessor_get_dim(grid_type, buf, acc, ijk + ijk_offset));
         pnanovdb_hdda_update(hdda, origin, direction, dim);
-        if (hdda.dim > 1 || !pnanovdb_readaccessor_is_active(grid_type, buf, acc, ijk))
+        if (hdda.dim > 1 || !pnanovdb_readaccessor_is_active(grid_type, buf, acc, ijk + ijk_offset))
         {
             continue;
         }
-        while (pnanovdb_hdda_step(hdda) && pnanovdb_readaccessor_is_active(grid_type, buf, acc, hdda.voxel))
+        while (pnanovdb_hdda_step(hdda) && pnanovdb_readaccessor_is_active(grid_type, buf, acc, hdda.voxel + ijk_offset))
         {
-            ijk = hdda.voxel;
-            float v = read_distance(grid_type, buf, acc, ijk);
+            float v = read_distance(grid_type, buf, acc, hdda.voxel + ijk_offset);
             float d = v - isovalue;
             if (d * d_prev < 0.f)
             {
@@ -202,7 +209,7 @@ bool surface_zero_crossing(pnanovdb_grid_type_t grid_type,
                             break;
                         }
                         float tm = 0.5f * (ta + tb);
-                        float dm = read_distance_trilinear(grid_type, buf, acc, origin + tm * direction) - isovalue;
+                        float dm = read_distance_trilinear(grid_type, buf, acc, origin + tm * direction, ijk_offset) - isovalue;
                         if (da * dm <= 0.f)
                         {
                             tb = tm;
@@ -240,7 +247,7 @@ bool render_surface(StructuredBuffer<uint2> buf, float3 worldRayOrigin, float3 w
     pnanovdb_readaccessor_t acc;
     pnanovdb_readaccessor_init(PNANOVDB_REF(acc), root);
 
-    // Transform ray into index space (HDDA + accessor operate in true index coords).
+    // Transform ray into index space.
     float3 origin = pnanovdb_grid_world_to_indexf(buf, grid, worldRayOrigin);
     float3 dir = pnanovdb_grid_world_to_index_dirf(buf, grid, worldRayDir);
     float dirMag = length(dir);
@@ -250,14 +257,29 @@ bool render_surface(StructuredBuffer<uint2> buf, float3 worldRayOrigin, float3 w
     }
     dir /= dirMag;
 
+    // Auto-centering: shift the float ray math by an integer (multiple-of-4096)
+    // offset so coordinates stay near the origin for off-origin grids. The
+    // offset is added back at every accessor/value lookup, so results are
+    // identical to true-index-space traversal, just with better float precision.
+    int3 ijk_offset = int3(0, 0, 0);
+    if (shader_params.auto_center != 0u)
+    {
+        int3 bbox_min = pnanovdb_root_get_bbox_min(buf, root);
+        int3 bbox_max = pnanovdb_root_get_bbox_max(buf, root);
+        int3 bbox_ave = ((bbox_max + bbox_min) >> 1u);
+        ijk_offset = (bbox_ave & ~4095);
+    }
+    float3 origin_local = origin - float3(ijk_offset);
+
     float thit;
-    if (!surface_zero_crossing(grid_type, buf, acc, origin, 0.f, dir, 1e9f, isovalue, shader_params.surface_eps, thit))
+    if (!surface_zero_crossing(
+            grid_type, buf, acc, origin_local, 0.f, dir, 1e9f, isovalue, shader_params.surface_eps, ijk_offset, thit))
     {
         return false;
     }
 
-    float3 hitPos = origin + thit * dir;
-    float3 n = surface_normal(grid_type, buf, acc, hitPos);
+    float3 hitPos = origin_local + thit * dir;
+    float3 n = surface_normal(grid_type, buf, acc, hitPos, ijk_offset);
 
     // Orient the normal toward the viewer.
     if (dot(n, -dir) < 0.f)

--- a/editor/shaders/editor_surface.slang
+++ b/editor/shaders/editor_surface.slang
@@ -22,8 +22,9 @@ struct shader_params_t
     uint auto_center;    // recenter the traversal near the origin in index space (float precision for off-origin grids)
     float ambient;      // ambient lighting term
 
-    float4 light_dir;     // world-space light direction; (0,0,0) -> headlight
     float4 surface_color; // base albedo (rgb)
+    float3 light_dir;     // world-space light direction; (0,0,0) -> headlight
+    float _pad1;
 };
 
 StructuredBuffer<uint2> buf;
@@ -288,9 +289,9 @@ bool render_surface(StructuredBuffer<uint2> buf, float3 worldRayOrigin, float3 w
     }
 
     float3 L;
-    if (length(shader_params.light_dir.xyz) > 1e-6f)
+    if (length(shader_params.light_dir) > 1e-6f)
     {
-        L = pnanovdb_grid_world_to_index_dirf(buf, grid, shader_params.light_dir.xyz);
+        L = pnanovdb_grid_world_to_index_dirf(buf, grid, shader_params.light_dir);
         float Llen = length(L);
         L = (Llen > 1e-8f) ? (L / Llen) : -dir;
     }

--- a/editor/shaders/editor_surface.slang
+++ b/editor/shaders/editor_surface.slang
@@ -1,0 +1,325 @@
+// editor_surface.slang
+//
+// SDF / level-set isosurface renderer.
+//
+// Finds the first zero-crossing of the signed scalar field along each camera
+// ray using hierarchical DDA traversal (the PNanoVDB HDDA helpers enabled via
+// PNANOVDB_HDDA), then shades the hit as an opaque surface. Supports FLOAT and
+// ONINDEX (float blind-data) grids. Output uses the same premultiplied
+// alpha-as-transmittance convention as editor.slang: alpha 0 == opaque,
+// alpha 1 == fully transparent (background shows through).
+#define PNANOVDB_HLSL
+#define PNANOVDB_ADDRESS_64
+#define PNANOVDB_BUF_HLSL_64
+#define PNANOVDB_HDDA
+#include "PNanoVDB.h"
+
+#include "editor_params.slang"
+
+struct shader_params_t
+{
+    float isovalue;     // iso level to extract (0 for level sets)
+    float surface_eps;  // index-space bisection tolerance (<= 0 disables refinement)
+    uint auto_center;    // reserved for parity with editor.slang (unused: HDDA traverses true index space)
+    float ambient;      // ambient lighting term
+
+    float4 light_dir;     // world-space light direction; (0,0,0) -> headlight
+    float4 surface_color; // base albedo (rgb)
+};
+
+StructuredBuffer<uint2> buf;
+RWStructuredBuffer<uint> image_out_deprecated;
+RWTexture2D<float4> texture_out;
+ConstantBuffer<EditorParams> editor_params;
+ConstantBuffer<shader_params_t> shader_params;
+
+// Read the raw signed scalar value at an integer coordinate, generalized across
+// grid types. This is the surface-finding analogue of editor.slang's
+// ray_march_nanovdb_leaf_fetch_float, but returns the value instead of a color
+// (and reinterprets ONINDEX blind float data with asfloat rather than asuint).
+float read_distance(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, int3 ijk)
+{
+    pnanovdb_grid_handle_t grid = { pnanovdb_address_null() };
+    pnanovdb_uint32_t level = 0u;
+    pnanovdb_address_t address =
+        pnanovdb_readaccessor_get_value_address_and_level(grid_type, buf, PNANOVDB_REF(acc), ijk, level);
+
+    float value = 0.f;
+    if (grid_type == PNANOVDB_GRID_TYPE_ONINDEX)
+    {
+        pnanovdb_gridblindmetadata_handle_t metadata = pnanovdb_grid_get_gridblindmetadata(buf, grid, 0u);
+        pnanovdb_uint64_t val_index64;
+        if (level == 0)
+        {
+            val_index64 = pnanovdb_leaf_onindex_get_value_index(buf, address, ijk);
+        }
+        else
+        {
+            val_index64 = pnanovdb_read_uint64(buf, address);
+        }
+        pnanovdb_uint32_t val_index = pnanovdb_uint64_low(val_index64);
+        pnanovdb_uint64_t value_count = pnanovdb_gridblindmetadata_get_value_count(buf, metadata);
+        pnanovdb_uint32_t value_raw = 0u;
+        if (val_index < pnanovdb_uint64_low(value_count))
+        {
+            pnanovdb_int64_t byte_offset = pnanovdb_gridblindmetadata_get_data_offset(buf, metadata);
+            pnanovdb_address_t val_addr =
+                pnanovdb_address_offset64(metadata.address, pnanovdb_int64_as_uint64(byte_offset));
+            val_addr = pnanovdb_address_offset_product(val_addr, val_index, 4u);
+            value_raw = pnanovdb_read_uint32(buf, val_addr);
+        }
+        value = asfloat(value_raw);
+    }
+    else if (grid_type == PNANOVDB_GRID_TYPE_FLOAT)
+    {
+        value = pnanovdb_read_float(buf, address);
+    }
+    else
+    {
+        // Mask / binary fallback: active voxel -> inside (-1), otherwise outside (+1).
+        if (!pnanovdb_address_is_null(PNANOVDB_DEREF(acc).leaf.address))
+        {
+            pnanovdb_uint32_t leaf_n = pnanovdb_leaf_coord_to_offset(PNANOVDB_REF(ijk));
+            value = pnanovdb_leaf_get_value_mask(buf, PNANOVDB_DEREF(acc).leaf, leaf_n) ? -1.f : 1.f;
+        }
+        else
+        {
+            value = 1.f;
+        }
+    }
+    return value;
+}
+
+// Trilinearly interpolated distance at an arbitrary index-space position. Voxel
+// values are treated as samples at integer (cell-center) coordinates, matching
+// editor.slang's compute_trilinear_weights convention.
+float read_distance_trilinear(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, float3 pos)
+{
+    float3 p = pos - 0.5f;
+    int3 ijk000 = int3(floor(p));
+    float3 w = p - float3(ijk000);
+
+    float result = 0.f;
+    [unroll]
+    for (int i = 0; i < 8; i++)
+    {
+        int3 o = int3(i & 1, (i >> 1) & 1, (i >> 2) & 1);
+        float wx = (o.x == 0) ? (1.f - w.x) : w.x;
+        float wy = (o.y == 0) ? (1.f - w.y) : w.y;
+        float wz = (o.z == 0) ? (1.f - w.z) : w.z;
+        result += wx * wy * wz * read_distance(grid_type, buf, acc, ijk000 + o);
+    }
+    return result;
+}
+
+// Index-space surface normal = normalized gradient of the field via central
+// differences of the trilinearly sampled distance.
+float3 surface_normal(pnanovdb_grid_type_t grid_type, StructuredBuffer<uint2> buf, inout pnanovdb_readaccessor_t acc, float3 pos)
+{
+    const float h = 1.f;
+    float dx = read_distance_trilinear(grid_type, buf, acc, pos + float3(h, 0.f, 0.f)) -
+               read_distance_trilinear(grid_type, buf, acc, pos - float3(h, 0.f, 0.f));
+    float dy = read_distance_trilinear(grid_type, buf, acc, pos + float3(0.f, h, 0.f)) -
+               read_distance_trilinear(grid_type, buf, acc, pos - float3(0.f, h, 0.f));
+    float dz = read_distance_trilinear(grid_type, buf, acc, pos + float3(0.f, 0.f, h)) -
+               read_distance_trilinear(grid_type, buf, acc, pos - float3(0.f, 0.f, h));
+    float3 n = float3(dx, dy, dz);
+    float len = length(n);
+    return (len > 1e-8f) ? (n / len) : float3(0.f, 0.f, 1.f);
+}
+
+// Generalized HDDA zero-crossing, adapted from pnanovdb_hdda_zero_crossing in
+// PNanoVDB.h. Differences: the scalar value read goes through read_distance (so
+// FLOAT and ONINDEX both work), the test is against an arbitrary isovalue, and
+// the hit t is refined between bracketing samples (linear, then optional
+// bisection on the trilinear field).
+bool surface_zero_crossing(pnanovdb_grid_type_t grid_type,
+                           StructuredBuffer<uint2> buf,
+                           inout pnanovdb_readaccessor_t acc,
+                           float3 origin,
+                           float tmin,
+                           float3 direction,
+                           float tmax,
+                           float isovalue,
+                           float eps,
+                           out float thit)
+{
+    thit = tmin;
+
+    pnanovdb_coord_t bbox_min = pnanovdb_root_get_bbox_min(buf, acc.root);
+    pnanovdb_coord_t bbox_max = pnanovdb_root_get_bbox_max(buf, acc.root);
+    float3 bbox_minf = pnanovdb_coord_to_vec3(bbox_min);
+    float3 bbox_maxf = pnanovdb_coord_to_vec3(pnanovdb_coord_add(bbox_max, pnanovdb_coord_uniform(1)));
+
+    bool hit = pnanovdb_hdda_ray_clip(bbox_minf, bbox_maxf, origin, tmin, direction, tmax);
+    if (!hit || tmax > 1.0e20f)
+    {
+        return false;
+    }
+
+    float3 pos = pnanovdb_hdda_ray_start(origin, tmin, direction);
+    pnanovdb_coord_t ijk = pnanovdb_hdda_pos_to_ijk(pos);
+
+    float v0 = read_distance(grid_type, buf, acc, ijk);
+    float d_prev = v0 - isovalue;
+    float t_prev = tmin;
+
+    int dim = pnanovdb_uint32_as_int32(pnanovdb_readaccessor_get_dim(grid_type, buf, acc, ijk));
+    pnanovdb_hdda_t hdda;
+    pnanovdb_hdda_init(hdda, origin, tmin, direction, tmax, dim);
+    while (pnanovdb_hdda_step(hdda))
+    {
+        float3 pos_start = pnanovdb_hdda_ray_start(origin, hdda.tmin + 1.0001f, direction);
+        ijk = pnanovdb_hdda_pos_to_ijk(pos_start);
+        dim = pnanovdb_uint32_as_int32(pnanovdb_readaccessor_get_dim(grid_type, buf, acc, ijk));
+        pnanovdb_hdda_update(hdda, origin, direction, dim);
+        if (hdda.dim > 1 || !pnanovdb_readaccessor_is_active(grid_type, buf, acc, ijk))
+        {
+            continue;
+        }
+        while (pnanovdb_hdda_step(hdda) && pnanovdb_readaccessor_is_active(grid_type, buf, acc, hdda.voxel))
+        {
+            ijk = hdda.voxel;
+            float v = read_distance(grid_type, buf, acc, ijk);
+            float d = v - isovalue;
+            if (d * d_prev < 0.f)
+            {
+                float t_curr = hdda.tmin;
+                float denom = d_prev - d;
+                float t_lin = (abs(denom) > 1e-12f) ? (t_prev + (t_curr - t_prev) * (d_prev / denom)) : t_curr;
+
+                if (eps > 0.f)
+                {
+                    // Bisection on the continuous trilinear field for a sub-voxel hit.
+                    float ta = t_prev;
+                    float tb = t_curr;
+                    float da = d_prev;
+                    [loop]
+                    for (int it = 0; it < 12; it++)
+                    {
+                        if ((tb - ta) <= eps)
+                        {
+                            break;
+                        }
+                        float tm = 0.5f * (ta + tb);
+                        float dm = read_distance_trilinear(grid_type, buf, acc, origin + tm * direction) - isovalue;
+                        if (da * dm <= 0.f)
+                        {
+                            tb = tm;
+                        }
+                        else
+                        {
+                            ta = tm;
+                            da = dm;
+                        }
+                    }
+                    thit = 0.5f * (ta + tb);
+                }
+                else
+                {
+                    thit = t_lin;
+                }
+                return true;
+            }
+            d_prev = d;
+            t_prev = hdda.tmin;
+        }
+    }
+    return false;
+}
+
+bool render_surface(StructuredBuffer<uint2> buf, float3 worldRayOrigin, float3 worldRayDir, float isovalue, out float3 hitColor)
+{
+    hitColor = float3(0.f, 0.f, 0.f);
+
+    pnanovdb_grid_handle_t grid = { pnanovdb_address_null() };
+    pnanovdb_tree_handle_t tree = pnanovdb_grid_get_tree(buf, grid);
+    pnanovdb_root_handle_t root = pnanovdb_tree_get_root(buf, tree);
+    pnanovdb_grid_type_t grid_type = pnanovdb_grid_get_grid_type(buf, grid);
+
+    pnanovdb_readaccessor_t acc;
+    pnanovdb_readaccessor_init(PNANOVDB_REF(acc), root);
+
+    // Transform ray into index space (HDDA + accessor operate in true index coords).
+    float3 origin = pnanovdb_grid_world_to_indexf(buf, grid, worldRayOrigin);
+    float3 dir = pnanovdb_grid_world_to_index_dirf(buf, grid, worldRayDir);
+    float dirMag = length(dir);
+    if (dirMag <= 0.f)
+    {
+        return false;
+    }
+    dir /= dirMag;
+
+    float thit;
+    if (!surface_zero_crossing(grid_type, buf, acc, origin, 0.f, dir, 1e9f, isovalue, shader_params.surface_eps, thit))
+    {
+        return false;
+    }
+
+    float3 hitPos = origin + thit * dir;
+    float3 n = surface_normal(grid_type, buf, acc, hitPos);
+
+    // Orient the normal toward the viewer.
+    if (dot(n, -dir) < 0.f)
+    {
+        n = -n;
+    }
+
+    float3 L;
+    if (length(shader_params.light_dir.xyz) > 1e-6f)
+    {
+        L = pnanovdb_grid_world_to_index_dirf(buf, grid, shader_params.light_dir.xyz);
+        float Llen = length(L);
+        L = (Llen > 1e-8f) ? (L / Llen) : -dir;
+    }
+    else
+    {
+        L = -dir; // headlight
+    }
+
+    float diffuse = max(0.f, dot(n, L));
+    float ambient = shader_params.ambient;
+    hitColor = shader_params.surface_color.rgb * (ambient + (1.f - ambient) * diffuse);
+    return true;
+}
+
+[shader("compute")][numthreads(16, 8, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    int2 tidx = int2(dispatchThreadID.xy);
+
+    float2 ndc = float2(2.f * ((float(tidx.x) + 0.5f) / float(editor_params.width)) - 1.f,
+                        -2.f * ((float(tidx.y) + 0.5f) / float(editor_params.height)) + 1.f);
+
+    float4 pos_d0 = mul(float4(ndc.xy, 0.f, 1.f), editor_params.projection_inv);
+    float4 pos_d1 = mul(float4(ndc.xy, 1.f, 1.f), editor_params.projection_inv);
+
+    float z_d0 = pos_d0.z * (1.f / pos_d0.w);
+    float z_d1 = pos_d1.z * (1.f / pos_d1.w);
+    bool is_reverse_z = abs(z_d0) > abs(z_d1);
+    float4 ray_dir_near = is_reverse_z ? pos_d1 : pos_d0;
+
+    float4 ray_dir_far = ray_dir_near + mul(float4(0.f, 0.f, 1.f, 0.f), editor_params.projection_inv);
+    float3 rayDir = normalize((ray_dir_far.xyz / ray_dir_far.w) - (ray_dir_near.xyz / ray_dir_near.w));
+    if (is_reverse_z)
+    {
+        rayDir = -rayDir;
+    }
+
+    rayDir = mul(float4(rayDir, 0.f), editor_params.view_inv).xyz;
+
+    float4 rayOrigin4 = is_reverse_z ? pos_d1 : pos_d0;
+    rayOrigin4 = mul(rayOrigin4, editor_params.view_inv);
+    float3 rayOrigin = rayOrigin4.xyz / rayOrigin4.w;
+
+    float3 hitColor;
+    bool hit = render_surface(buf, rayOrigin, rayDir, shader_params.isovalue, hitColor);
+    if (hit)
+    {
+        texture_out[tidx] = float4(hitColor, 0.f);
+    }
+    else
+    {
+        texture_out[tidx] = float4(0.f, 0.f, 0.f, 1.f);
+    }
+}

--- a/editor/shaders/editor_surface.slang.json
+++ b/editor/shaders/editor_surface.slang.json
@@ -25,17 +25,6 @@
             "max": 1,
             "step": 0.01
         },
-        "light_dir": {
-            "value": [
-                0,
-                0,
-                0,
-                0
-            ],
-            "min": -1,
-            "max": 1,
-            "step": 0.01
-        },
         "surface_color": {
             "value": [
                 0.8,
@@ -44,6 +33,16 @@
                 1
             ],
             "min": 0,
+            "max": 1,
+            "step": 0.01
+        },
+        "light_dir": {
+            "value": [
+                0,
+                0,
+                0
+            ],
+            "min": -1,
             "max": 1,
             "step": 0.01
         }

--- a/editor/shaders/editor_surface.slang.json
+++ b/editor/shaders/editor_surface.slang.json
@@ -1,0 +1,51 @@
+{
+    "ShaderParams": {
+        "isovalue": {
+            "value": 0,
+            "min": -10,
+            "max": 10,
+            "step": 0.01
+        },
+        "surface_eps": {
+            "value": 0.01,
+            "min": 0,
+            "max": 1,
+            "step": 0.001
+        },
+        "auto_center": {
+            "value": 0,
+            "min": 0,
+            "max": 1,
+            "step": 1,
+            "isBool": true
+        },
+        "ambient": {
+            "value": 0.15,
+            "min": 0,
+            "max": 1,
+            "step": 0.01
+        },
+        "light_dir": {
+            "value": [
+                0,
+                0,
+                0,
+                0
+            ],
+            "min": -1,
+            "max": 1,
+            "step": 0.01
+        },
+        "surface_color": {
+            "value": [
+                0.8,
+                0.8,
+                0.85,
+                1
+            ],
+            "min": 0,
+            "max": 1,
+            "step": 0.01
+        }
+    }
+}


### PR DESCRIPTION
Adds a new **"NanoVDB Surface (SDF)"** render pipeline that renders signed-distance / level-set grids as a shaded opaque isosurface, complementing the existing volumetric ray-march path (`editor/editor.slang`). Instead of integrating color along the ray, it finds the first iso-crossing of the field via hierarchical DDA (HDDA) traversal, computes a gradient normal, and shades the hit with simple Lambertian lighting.

The surface finder is built on `pnanovdb_hdda_zero_crossing` from `PNanoVDB.h` (`HDDA.h`'s `ZeroCrossing` GPU port), generalized to work on both `FLOAT` and `ONINDEX` grids.


## What changed

| File | Change |
| --- | --- |
| `editor/shaders/editor_surface.slang` | New compute shader implementing the surface render path. |
| `editor/shaders/editor_surface.slang.json` | New shader-param schema (UI controls + constant-buffer layout). |
| `editor/PipelineTypes.h` | New `pnanovdb_pipeline_type_nanovdb_surface` enum value. |
| `editor/Pipeline.cpp` | Registers the `s_nanovdb_surface_descriptor` pipeline ("NanoVDB Surface (SDF)"). |

## How it works

Per camera ray, `editor_surface.slang`:

1. **`read_distance`** — reads the raw signed scalar value generically across grid types:
   - `FLOAT`: direct `pnanovdb_read_float`.
   - `ONINDEX`: value index from the tree, then a 4-byte read from blind-metadata index 0, reinterpreted with `asfloat` (this fixes the `asuint` bit-reinterpret bug that exists in `editor.slang`'s ONINDEX path).
   - Mask/other: active-voxel fallback.
2. **`surface_zero_crossing`** — adapted from `pnanovdb_hdda_zero_crossing` (enabled via `#define PNANOVDB_HDDA`). Same adaptive HDDA traversal (ray clip, dim-based level skipping, active-voxel stepping), but the value read goes through `read_distance`, the test is against an arbitrary `isovalue`, and the hit `t` is refined by linear interpolation plus optional trilinear-field bisection (`surface_eps`).
3. **`surface_normal`** — normalized gradient of the field via central differences of the trilinearly-sampled distance.
4. **Shading** — Lambertian with ambient. `light_dir` of `(0,0,0)` uses a headlight (`-rayDir`); otherwise a world-space directional light. Output follows the codebase's premultiplied alpha-as-transmittance convention: opaque on hit (`alpha = 0`), transparent on miss (`alpha = 1`).

Resource bindings mirror `editor.slang` exactly so the existing `dispatch_shader_on_nanovdb_array` path drives it unchanged. The pipeline descriptor reuses the existing `NanoVDBRenderParams` init/execute/map/render-method functions; only the default shader differs.

```mermaid
flowchart TD
    UI["Properties: render pipeline = NanoVDB Surface (SDF)"] --> Shader["editor_surface.slang :: main"]
    Shader --> ZC["surface_zero_crossing (HDDA)"]
    ZC --> Fetch["read_distance: FLOAT or ONINDEX float"]
    ZC --> Normal["gradient normal (central differences)"]
    Normal --> Shade["Lambertian + ambient"]
    Shade --> Out["texture_out: opaque on hit / transparent on miss"]
```

## Grid format support

- `PNANOVDB_GRID_TYPE_FLOAT` — supported.
- `PNANOVDB_GRID_TYPE_ONINDEX` with a float value array at blind-metadata index 0 — supported (a `FloatGrid` is **not** required).
- Mask grids — limited; the active-only HDDA traversal means a pure binary mask has no sign variation to cross.

## Shader parameters

Exposed in the Properties panel (`editor_surface.slang.json`): `isovalue`, `surface_eps`, `auto_center`, `ambient`, `light_dir`, `surface_color`. Field order is arranged so each `float4` is 16-byte aligned, matching the tight packing performed by `ShaderParams::copy_params_to_buffer`.

## Usage

- Select the volume under NanoVDBs and set the render pipeline to **"NanoVDB Surface (SDF)"** in the Properties panel (this auto-selects `editor/editor_surface.slang`), or type the shader name directly in the "Shader:" field.
- From the app directly:

```bash
./build/Release/pnanovdbeditorapp --input /path/to/your_sdf.nvdb --shader editor/editor_surface.slang
```