### PR TITLE
Change VoxelBVH voxel value bit packing.

### DIFF
--- a/editor/shaders/voxelbvh_common.h
+++ b/editor/shaders/voxelbvh_common.h
@@ -1,4 +1,13 @@
-// voxelbvh_common.h
+// Copyright Contributors to the OpenVDB Project
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+    \file   editor/shaders/voxelbvh_common.h
+
+    \author Andrew Reidmeyer
+
+    \brief
+*/
 
 #ifndef VOXELBVH_COMMON_SLANG
 #define VOXELBVH_COMMON_SLANG

--- a/editor/shaders/voxelbvh_common.h
+++ b/editor/shaders/voxelbvh_common.h
@@ -1,0 +1,30 @@
+// voxelbvh_common.h
+
+#ifndef VOXELBVH_COMMON_SLANG
+#define VOXELBVH_COMMON_SLANG
+
+PNANOVDB_FORCE_INLINE pnanovdb_uint32_t voxelbvh_get_active_level_mask(pnanovdb_uint64_t voxel_val_raw)
+{
+    return pnanovdb_uint32_t(voxel_val_raw) & 0x0FFF;
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_uint32_t voxelbvh_get_skip_level(pnanovdb_uint64_t voxel_val_raw)
+{
+    return (pnanovdb_uint32_t(voxel_val_raw) >> 12u) & 0x000F;
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_uint64_t voxelbvh_get_first_range_idx(pnanovdb_uint64_t voxel_val_raw)
+{
+    return voxel_val_raw >> 16u;
+}
+
+PNANOVDB_FORCE_INLINE pnanovdb_uint64_t voxelbvh_make_voxel_val(pnanovdb_uint32_t active_level_mask,
+                                                                pnanovdb_uint32_t skip_level,
+                                                                pnanovdb_uint64_t first_range_idx)
+{
+    active_level_mask = active_level_mask & 0x0FFF;
+    skip_level = skip_level & 0x000F;
+    return (first_range_idx << 16u) | pnanovdb_uint64_t((skip_level << 12u) | active_level_mask);
+}
+
+#endif

--- a/editor/shaders/voxelbvh_debug.slang
+++ b/editor/shaders/voxelbvh_debug.slang
@@ -5,6 +5,7 @@
 #include "PNanoVDB.h"
 
 #include "editor_params.slang"
+#include "voxelbvh_common.h"
 
 struct shader_params_t
 {
@@ -78,9 +79,9 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
 
     pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, ijk);
     uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
-    uint active_level_mask = uint(val_raw) & 0xFFFF;
-    uint skip_level = (uint(val_raw) >> 16u) & 0xFFFF;
-    uint list_begin_idx = uint(val_raw >> 32u);
+    uint active_level_mask = voxelbvh_get_active_level_mask(val_raw);
+    uint skip_level = voxelbvh_get_skip_level(val_raw);
+    uint first_range_idx = voxelbvh_get_first_range_idx(val_raw);
 
     float4 value = float4(0.f, 0.f, 0.f, 0.f);
 
@@ -90,7 +91,7 @@ void main(uint3 dispatchThreadID : SV_DispatchThreadID)
     }
     if (shader_params.show_list_ids != 0u)
     {
-        skip_level = list_begin_idx % 12;
+        skip_level = first_range_idx % 12;
     }
     if (shader_params.show_nanovdb_level != 0u)
     {

--- a/editor/shaders/voxelbvh_gaussians.slang
+++ b/editor/shaders/voxelbvh_gaussians.slang
@@ -554,7 +554,7 @@ void ray_hdda_nanovdb(uint thread_idx,
             {
                 pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, hdda.hdda.ijk);
                 uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
-                uint skip_level = (uint(val_raw) >> 16u) & 0xFFFF;
+                uint skip_level = voxelbvh_get_skip_level(val_raw);
 
                 // align HDDA tmin/tmax to current voxel size
                 dim = 1 << skip_level;

--- a/editor/shaders/voxelbvh_lines.slang
+++ b/editor/shaders/voxelbvh_lines.slang
@@ -251,7 +251,7 @@ void ray_hdda_nanovdb(uint thread_idx,
             {
                 pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, hdda.hdda.ijk);
                 uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
-                uint skip_level = (uint(val_raw) >> 16u) & 0xFFFF;
+                uint skip_level = voxelbvh_get_skip_level(val_raw);
 
                 // align HDDA tmin/tmax to current voxel size
                 dim = 1 << skip_level;

--- a/editor/shaders/voxelbvh_triangles.slang
+++ b/editor/shaders/voxelbvh_triangles.slang
@@ -243,7 +243,7 @@ void ray_hdda_nanovdb(uint thread_idx,
             {
                 pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, hdda.hdda.ijk);
                 uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
-                uint skip_level = (uint(val_raw) >> 16u) & 0xFFFF;
+                uint skip_level = voxelbvh_get_skip_level(val_raw);
 
                 // align HDDA tmin/tmax to current voxel size
                 dim = 1 << skip_level;

--- a/editor/shaders/voxelbvh_triangles_debug.slang
+++ b/editor/shaders/voxelbvh_triangles_debug.slang
@@ -337,9 +337,9 @@ void ray_debug_plane(
 
         pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, ijk);
         uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
-        uint active_level_mask = uint(val_raw) & 0xFFFF;
-        uint skip_level = (uint(val_raw) >> 16u) & 0xFFFF;
-        uint list_begin_idx = uint(val_raw >> 32u);
+        uint active_level_mask = voxelbvh_get_active_level_mask(val_raw);
+        uint skip_level = uvoxelbvh_get_skip_levelint(val_raw);
+        uint first_range_idx = voxelbvh_get_first_range_idx(val_raw);
 
         uint border_level = skip_level;
         uint color_idx = skip_level;
@@ -350,7 +350,7 @@ void ray_debug_plane(
         }
         if (shader_params.show_list_ids != 0u)
         {
-            color_idx = list_begin_idx % 12;
+            color_idx = first_range_idx % 12;
         }
         if (shader_params.show_inactive != 0u)
         {
@@ -475,7 +475,7 @@ void ray_hdda_nanovdb(uint thread_idx,
             {
                 pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, hdda.hdda.ijk);
                 uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
-                uint skip_level = (uint(val_raw) >> 16u) & 0xFFFF;
+                uint skip_level = voxelbvh_get_skip_level(val_raw);
 
                 // align HDDA tmin/tmax to current voxel size
                 dim = 1 << skip_level;

--- a/editor/shaders/voxelbvh_triangles_debug.slang
+++ b/editor/shaders/voxelbvh_triangles_debug.slang
@@ -338,7 +338,7 @@ void ray_debug_plane(
         pnanovdb_address_t addr = pnanovdb_readaccessor_get_value_address(grid_type, buf, acc, ijk);
         uint64_t val_raw = pnanovdb_read_uint64(buf, addr);
         uint active_level_mask = voxelbvh_get_active_level_mask(val_raw);
-        uint skip_level = uvoxelbvh_get_skip_levelint(val_raw);
+        uint skip_level = voxelbvh_get_skip_level(val_raw);
         uint first_range_idx = voxelbvh_get_first_range_idx(val_raw);
 
         uint border_level = skip_level;

--- a/editor/shaders/workgroup_hdda.slang
+++ b/editor/shaders/workgroup_hdda.slang
@@ -105,7 +105,7 @@ bool workgroup_hdda_step(inout workgroup_hdda_t hdda, uint thread_idx, float3 ra
         {
             hdda.needs_update = true;
 
-            uint skip_level = (uint(s_voxel_val[s_hdda_min_idx]) >> 16u) & 0xFFFF;
+            uint skip_level = voxelbvh_get_skip_level(s_voxel_val[s_hdda_min_idx]);
             // align HDDA tmin/tmax to current voxel size
             int dim = 1 << skip_level;
             hdda_step(hdda.hdda, rayOrigin, rayDir, rayDirInv, dim);

--- a/editor/shaders/workgroup_voxelbvh.slang
+++ b/editor/shaders/workgroup_voxelbvh.slang
@@ -1,5 +1,7 @@
 // workgroup_voxelbvh.slang
 
+#include "voxelbvh_common.h"
+
 groupshared uint64_t s_range[12u];
 
 struct workgroup_voxelbvh_iterator_t
@@ -17,8 +19,8 @@ void workgroup_voxelbvh_iterator_init(
     pnanovdb_grid_handle_t grid,
     uint64_t voxel_val_raw)
 {
-    uint active_level_mask = uint(voxel_val_raw) & 0xFFFF;
-    uint list_begin_idx = uint(voxel_val_raw >> 32u);
+    uint active_level_mask = voxelbvh_get_active_level_mask(voxel_val_raw);
+    uint first_range_idx = uint(voxelbvh_get_first_range_idx(voxel_val_raw));
 
     iter.pass_idx = 0u;
     iter.active_level_count = countbits(active_level_mask);
@@ -28,7 +30,7 @@ void workgroup_voxelbvh_iterator_init(
         if (thread_idx < iter.active_level_count)
         {
             pnanovdb_address_t range_addr = pnanovdb_grid_get_gridblindmetadata_value_address(buf, grid, 0u);
-            range_addr = pnanovdb_address_offset_product(range_addr, 8u, list_begin_idx);
+            range_addr = pnanovdb_address_offset_product(range_addr, 8u, first_range_idx);
             range = pnanovdb_read_uint64(buf, pnanovdb_address_offset(range_addr, 8u * thread_idx));
         }
         s_range[thread_idx] = range;

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_duplicate.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_duplicate.slang
@@ -6,6 +6,7 @@ struct user_state_t
 }
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 void nanovdb_set_bit(RWStructuredBuffer<uint2> write_buf, pnanovdb_address_t addr, uint bit_idx)
 {
@@ -115,7 +116,7 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
             // Add extra leaves for mid sized primitives
             // Mask applied here is a heuristic
             pnanovdb_uint64_t voxel_val_raw = pnanovdb_read_uint64(buf, val_addr);
-            uint active_level_mask = uint(voxel_val_raw) & 0xFFFF;
+            uint active_level_mask = voxelbvh_get_active_level_mask(voxel_val_raw);
             if ((active_level_mask & 0x1F) != 0u)
             {
                 src_child_is_active = true;

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_alloc1.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_alloc1.slang
@@ -6,6 +6,7 @@ struct user_state_t
 };
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 RWStructuredBuffer<uint2> workgroup_counters_inout;
 
@@ -18,8 +19,8 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
     if (!pnanovdb_address_is_null(val_addr))
     {
         pnanovdb_uint32_t val = pnanovdb_read_uint32(buf, val_addr);
-        uint active_lmask = val & 0xFFFF;
-        alloc_count = countbits(active_lmask);
+        uint active_level_mask = voxelbvh_get_active_level_mask(val);
+        alloc_count = countbits(active_level_mask);
     }
     user_state.element_count = user_state.element_count + alloc_count;
 }

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_alloc3.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_alloc3.slang
@@ -6,6 +6,7 @@ struct user_state_t
 };
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 StructuredBuffer<uint2> workgroup_counters_inout;
 
@@ -21,8 +22,8 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
     if (!pnanovdb_address_is_null(val_addr))
     {
         val = pnanovdb_read_uint64(buf, val_addr);
-        uint active_lmask = uint(val) & 0xFFFF;
-        alloc_count = countbits(active_lmask);
+        uint active_level_mask = voxelbvh_get_active_level_mask(val);
+        alloc_count = countbits(active_level_mask);
     }
 
     uint64_t4 alloc_count4 = uint64_t4(alloc_count, 0llu, 0llu, 0llu);
@@ -35,7 +36,15 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
         uint64_t val_alloc_idx = user_state.workgroup_alloc_idx + scan_alloc_count4.x - alloc_count4.x;
         // voxel value is only 32-bit for now
         uint val_alloc_idx32 = alloc_count == 0u ? 0u : uint(val_alloc_idx);
-        val = val | (uint64_t(val_alloc_idx32) << 32u);
+
+        uint active_level_mask = voxelbvh_get_active_level_mask(val);
+        uint skip_level = voxelbvh_get_skip_level(val);
+        uint64_t first_range_idx = voxelbvh_get_first_range_idx(val);
+
+        first_range_idx = val_alloc_idx32;
+
+        val = voxelbvh_make_voxel_val(active_level_mask, skip_level, first_range_idx);
+
         pnanovdb_write_uint64(buf, val_addr, val);
     }
 

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_flatten.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_flatten.slang
@@ -6,6 +6,7 @@ struct user_state_t
 }
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 RWStructuredBuffer<uint2> range_flat_inout;
 
@@ -24,11 +25,11 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
     pnanovdb_root_handle_t root = pnanovdb_tree_get_root(buf, tree);
 
     pnanovdb_uint64_t ref_val = pnanovdb_read_uint64(buf, val_addr);
-    if (uint(ref_val & 0xFFFF) != 0)
+    if (voxelbvh_get_active_level_mask(ref_val) != 0)
     {
         for (uint l = 0u; l < 12; l++)
         {
-            if ((uint(ref_val & 0xFFFF) & (1u << l)) != 0u)
+            if ((voxelbvh_get_active_level_mask(ref_val) & (1u << l)) != 0u)
             {
                 uint lmask = ~((1u << l) - 1u);
                 pnanovdb_coord_t ijkmask = ijk & lmask;
@@ -36,8 +37,8 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
                 pnanovdb_address_t read_val_addr = pnanovdb_root_get_value_address(grid_type, buf, root, ijkmask);
                 pnanovdb_uint64_t read_val = pnanovdb_read_uint64(buf, read_val_addr);
 
-                uint ref_list_idx = uint(ref_val >> 32u) + countbits(uint(ref_val) & ~lmask);
-                uint read_list_idx = uint(read_val >> 32u) + countbits(uint(read_val) & ~lmask);
+                uint ref_list_idx = uint(voxelbvh_get_first_range_idx(ref_val)) + countbits(uint(ref_val) & ~lmask);
+                uint read_list_idx = uint(voxelbvh_get_first_range_idx(read_val)) + countbits(uint(read_val) & ~lmask);
                 if (ref_list_idx != read_list_idx)
                 {
                     range_flat_inout[ref_list_idx] = range_flat_inout[read_list_idx];

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_splat.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_splat.slang
@@ -5,6 +5,8 @@
 #define PNANOVDB_BUF_HLSL_RW
 #include "PNanoVDB.h"
 
+#include "voxelbvh_common.h"
+
 struct constants_t
 {
     uint nanovdb_word_count;
@@ -69,9 +71,9 @@ void main(uint3 group_idx : SV_GroupID, uint3 thread_idx : SV_GroupThreadID)
 
     pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, address);
 
-    uint active_lmask = uint(val & 0xFFFF);
-    uint list_begin_idx = uint(val >> 32u);
-    uint list_idx = list_begin_idx + countbits(active_lmask & ~lmask);
+    uint active_level_mask = voxelbvh_get_active_level_mask(val);
+    uint first_range_idx = uint(voxelbvh_get_first_range_idx(val));
+    uint range_idx = first_range_idx + countbits(active_level_mask & ~lmask);
 
-    range_flat_out[list_idx] = range;
+    range_flat_out[range_idx] = range;
 }

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_spread.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_list_spread.slang
@@ -6,6 +6,7 @@ struct user_state_t
 }
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint level, uint n,
                   pnanovdb_coord_t ijk, inout user_state_t user_state)
@@ -22,7 +23,7 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
     pnanovdb_root_handle_t root = pnanovdb_tree_get_root(buf, tree);
 
     pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, val_addr);
-    if (uint(val & 0xFFFF) == 0)
+    if (voxelbvh_get_active_level_mask(val) == 0)
     {
         for (uint l = 1u; l < 12; l++)
         {
@@ -32,19 +33,19 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
             pnanovdb_address_t read_val_addr = pnanovdb_root_get_value_address(grid_type, buf, root, ijkmask);
             pnanovdb_uint64_t read_val = pnanovdb_read_uint64(buf, read_val_addr);
 
-            uint read_active_level_mask = uint(read_val) & 0xFFFF;
+            uint read_active_level_mask = voxelbvh_get_active_level_mask(read_val);
             if ((read_active_level_mask & lmask) != 0u)
             {
-                uint read_list_begin_idx = uint(read_val >> 32u);
-                uint read_skip_level = (uint(read_val) >> 16u) & 0xFFFF;
+                uint read_first_range_idx = uint(voxelbvh_get_first_range_idx(read_val));
+                uint read_skip_level = voxelbvh_get_skip_level(read_val);
 
                 // the lsbs of the active level mask are false positives for this voxel
                 // we should dump the lsbs of the active level mask and offset the list begin accordingly
                 uint active_level_mask = read_active_level_mask & lmask;
-                uint list_begin_idx = read_list_begin_idx + countbits(read_active_level_mask & ~lmask);
+                uint first_range_idx = read_first_range_idx + countbits(read_active_level_mask & ~lmask);
                 uint skip_level = read_skip_level;
 
-                val = (uint64_t(list_begin_idx) << 32u) | uint64_t((skip_level << 16u) | active_level_mask);
+                val = voxelbvh_make_voxel_val(active_level_mask, skip_level, first_range_idx);
                 break;
             }
         }

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_mask_flatten.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_level_mask_flatten.slang
@@ -6,6 +6,7 @@ struct user_state_t
 }
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint level, uint n,
                   pnanovdb_coord_t ijk, inout user_state_t user_state)
@@ -22,7 +23,7 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
     pnanovdb_root_handle_t root = pnanovdb_tree_get_root(buf, tree);
 
     pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, val_addr);
-    if ((uint(val) & 0xFFFF) != 0u)
+    if (voxelbvh_get_active_level_mask(val) != 0u)
     {
         for (uint l = 0u; l < 12; l++)
         {

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_merge_voxels.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_merge_voxels.slang
@@ -6,6 +6,7 @@ struct user_state_t
 }
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 struct merge_arg_t
 {
@@ -32,7 +33,7 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
     uint l = merge_arg_in.level;
     int flip_mask = 1 << l;
 
-    if ((uint(val >> 16u) & 0xFFFF) == l)
+    if (voxelbvh_get_skip_level(val) == l)
     {
         bool all_match = true;
         for (uint i = 1u; i < 8; i++)
@@ -59,7 +60,13 @@ void iterate_main(pnanovdb_address_t node_arr, pnanovdb_address_t val_addr, uint
         }
         if (all_match)
         {
-            val = (val & ~uint64_t(0xFFFF0000)) | uint64_t(((l + 1) & 0xFFFF) << 16u);
+            uint active_level_mask = voxelbvh_get_active_level_mask(val);
+            uint skip_level = voxelbvh_get_skip_level(val);
+            uint64_t first_range_idx = voxelbvh_get_first_range_idx(val);
+
+            skip_level = l + 1;
+
+            val = voxelbvh_make_voxel_val(active_level_mask, skip_level, first_range_idx);
         }
     }
 

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_rgba8_from_voxelbvh.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_rgba8_from_voxelbvh.slang
@@ -6,6 +6,7 @@ struct user_state_t
 }
 
 #include "voxelbvh_nanovdb_iterate.slang"
+#include "voxelbvh_common.h"
 
 struct constants2_t
 {
@@ -36,8 +37,8 @@ void workgroup_voxelbvh_iterator_init(
     pnanovdb_grid_handle_t grid,
     uint64_t voxel_val_raw)
 {
-    uint active_level_mask = uint(voxel_val_raw) & 0xFFFF;
-    uint list_begin_idx = uint(voxel_val_raw >> 32u);
+    uint active_level_mask = voxelbvh_get_active_level_mask(voxel_val_raw);
+    uint first_range_idx = uint(voxelbvh_get_first_range_idx(voxel_val_raw));
 
     iter.pass_idx = 0u;
     iter.active_level_count = countbits(active_level_mask);
@@ -47,7 +48,7 @@ void workgroup_voxelbvh_iterator_init(
         if (thread_idx < iter.active_level_count)
         {
             pnanovdb_address_t range_addr = pnanovdb_grid_get_gridblindmetadata_value_address(buf_scratch, grid, 0u);
-            range_addr = pnanovdb_address_offset_product(range_addr, 8u, list_begin_idx);
+            range_addr = pnanovdb_address_offset_product(range_addr, 8u, first_range_idx);
             range = pnanovdb_read_uint64(buf_scratch, pnanovdb_address_offset(range_addr, 8u * thread_idx));
         }
         s_range[thread_idx] = range;

--- a/raster/shaders/voxelbvh/voxelbvh_nanovdb_set_mask_ijkl_apply.slang
+++ b/raster/shaders/voxelbvh/voxelbvh_nanovdb_set_mask_ijkl_apply.slang
@@ -77,7 +77,7 @@ void main(uint3 group_idx : SV_GroupID, uint3 thread_idx : SV_GroupThreadID)
     if (range_scratch_val.x != 0u)
     {
         pnanovdb_address_t addr = {range_scratch_val & ((uint64_t(1u) << 48u) - 1u)};
-        uint n = (range_scratch_val >> 48u);
+        uint n = uint(range_scratch_val >> 48u);
         nanovdb_set_bit(addr, n);
     }
 }

--- a/test/TestVoxelBVH.cpp
+++ b/test/TestVoxelBVH.cpp
@@ -20,6 +20,8 @@
 #include <cstdio>
 #include <math.h>
 
+#include "editor/shaders/voxelbvh_common.h"
+
 static void save_ply(pnanovdb_compute_t& compute,
                      pnanovdb_compute_array_t* positions,
                      pnanovdb_compute_array_t* indices,
@@ -481,12 +483,12 @@ void voxelbvh_test()
                                 pnanovdb_address_t val_addr =
                                     pnanovdb_leaf_get_table_address(grid_type, buf, leaf, leaf_n);
                                 pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, val_addr);
-                                pnanovdb_uint32_t list_idx = pnanovdb_uint32_t(val >> 32u);
+                                pnanovdb_uint32_t list_idx = voxelbvh_get_first_range_idx(val);
                                 if (list_idx > max_list_idx)
                                 {
                                     max_list_idx = list_idx;
                                 }
-                                bit_count += pnanovdb_uint64_countbits(val & 0xFFFF);
+                                bit_count += pnanovdb_uint64_countbits(voxelbvh_get_active_level_mask(val));
                             }
                         }
                         else
@@ -494,12 +496,12 @@ void voxelbvh_test()
                             pnanovdb_address_t val_addr =
                                 pnanovdb_lower_get_table_address(grid_type, buf, lower, lower_n);
                             pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, val_addr);
-                            pnanovdb_uint32_t list_idx = pnanovdb_uint32_t(val >> 32u);
+                            pnanovdb_uint32_t list_idx = voxelbvh_get_first_range_idx(val);
                             if (list_idx > max_list_idx)
                             {
                                 max_list_idx = list_idx;
                             }
-                            bit_count += pnanovdb_uint64_countbits(val & 0xFFFF);
+                            bit_count += pnanovdb_uint64_countbits(voxelbvh_get_active_level_mask(val));
                         }
                     }
                 }
@@ -507,12 +509,12 @@ void voxelbvh_test()
                 {
                     pnanovdb_address_t val_addr = pnanovdb_upper_get_table_address(grid_type, buf, upper, upper_n);
                     pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, val_addr);
-                    pnanovdb_uint32_t list_idx = pnanovdb_uint32_t(val >> 32u);
+                    pnanovdb_uint32_t list_idx = voxelbvh_get_first_range_idx(val);
                     if (list_idx > max_list_idx)
                     {
                         max_list_idx = list_idx;
                     }
-                    bit_count += pnanovdb_uint64_countbits(val & 0xFFFF);
+                    bit_count += pnanovdb_uint64_countbits(voxelbvh_get_active_level_mask(val));
                 }
             }
         }
@@ -520,12 +522,12 @@ void voxelbvh_test()
         {
             pnanovdb_address_t val_addr = pnanovdb_root_tile_get_value_address(grid_type, buf, tile);
             pnanovdb_uint64_t val = pnanovdb_read_uint64(buf, val_addr);
-            pnanovdb_uint32_t list_idx = pnanovdb_uint32_t(val >> 32u);
+            pnanovdb_uint32_t list_idx = voxelbvh_get_first_range_idx(val);
             if (list_idx > max_list_idx)
             {
                 max_list_idx = list_idx;
             }
-            bit_count += pnanovdb_uint64_countbits(val & 0xFFFF);
+            bit_count += pnanovdb_uint64_countbits(voxelbvh_get_active_level_mask(val));
         }
     }
     printf("node_counts: root(%u) upper(%u) lower(%u) leaf(%u)\n", root_tile_count, upper_count, lower_count, leaf_count);
@@ -584,10 +586,10 @@ void voxelbvh_test()
                 val_pass_count++;
             }
 
-            pnanovdb_uint32_t active_lmask = pnanovdb_uint32_t(val & 0xFFFF);
-            pnanovdb_uint32_t list_begin_idx = pnanovdb_uint32_t(val >> 32u);
-            pnanovdb_uint32_t list_countbits = pnanovdb_uint32_countbits(active_lmask & ~lmask);
-            pnanovdb_uint32_t list_idx = list_begin_idx + list_countbits;
+            pnanovdb_uint32_t active_level_mask = voxelbvh_get_active_level_mask(val);
+            pnanovdb_uint32_t first_range_idx = voxelbvh_get_first_range_idx(val);
+            pnanovdb_uint32_t list_countbits = pnanovdb_uint32_countbits(active_level_mask & ~lmask);
+            pnanovdb_uint32_t list_idx = first_range_idx + list_countbits;
             uint64_t range_val = range_flat_ptr[list_idx];
             if (list_countbits != 0u)
             {
@@ -605,10 +607,10 @@ void voxelbvh_test()
             }
 
             pnanovdb_uint32_t range_flat_count = 0u;
-            pnanovdb_uint32_t list_flat_countbits = pnanovdb_uint32_countbits(active_lmask & 0xFFFF);
+            pnanovdb_uint32_t list_flat_countbits = pnanovdb_uint32_countbits(active_level_mask & 0xFFFF);
             for (pnanovdb_uint32_t sub_idx = 0u; sub_idx < list_flat_countbits; sub_idx++)
             {
-                uint64_t range_flat_val = range_flat_ptr[list_begin_idx + sub_idx];
+                uint64_t range_flat_val = range_flat_ptr[first_range_idx + sub_idx];
                 uint32_t range_flat_begin = uint32_t(range_flat_val);
                 uint32_t range_flat_end = uint32_t(range_flat_val >> 32u);
                 range_flat_count += range_flat_end - range_flat_begin;
@@ -616,7 +618,7 @@ void voxelbvh_test()
             if (range_flat_count > range_flat_count_max)
             {
                 range_flat_count_max = range_flat_count;
-                range_flat_mask_max = active_lmask;
+                range_flat_mask_max = active_level_mask;
             }
 
             if (addr.byte_offset != addr_old.byte_offset)


### PR DESCRIPTION
This does break the binary compatibility vs old VoxelBVH files.

Takes active_level_mask from 16 bits to 12 bits, since 4096 align with NanoVDB upper node coverage.
Takes skip_level to 4 bits, since 4 bits is enough to cover a max skip_level of 12.
Renames list_begin_idx to more accurate first_range_idx. Take from 32-bit to 48-bit to allow more total ranges.